### PR TITLE
Wasm: measure full compilation down to `.wasm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ build/bin/native/releaseExecutable/prime-multiplatform.kexe
 
 Compile
 ```
-./gradlew clean wasmMainClasses
+./gradlew clean compileProductionExecutableKotlinWasm
 ```
 Run
 ```


### PR DESCRIPTION
`wasmMainClasses` only produces intermediate "klib" artefact, which is unfair to other platforms producing final artefacts. It could also add some extra `.klib` -> `.wasm` compilation time to subsequent `wasmNodeProductionRun`